### PR TITLE
Fix few seconds off issue in send_reminder loop

### DIFF
--- a/study_cafe.py
+++ b/study_cafe.py
@@ -70,7 +70,7 @@ async def send_reminder():
         if doc["level"] == 2:
             now = datetime.now()
             # if time is 30 minutes past 
-            if (now - doc["start_time"]).total_seconds() % 1800 == 0:
+            if ((now - doc["start_time"]).total_seconds()//60) % 30 == 0:
                 user_id = doc["user"]
                 user = await client.fetch_user(user_id)
                 await user.send("<@" + str(user_id) + "> reminder to focus, are you on track?")


### PR DESCRIPTION
Convert seconds to Minutes to ensure this loop is always hit if few seconds are off. 